### PR TITLE
Add Oh My Zsh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,20 @@ unfunction _sfdx && autoload -U _sfdx
 ```
 
 Enjoy!
+
+## Oh My Zsh
+
+Users of [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh) can import this auto-completion as a plugin. To install it, just clone this repository into the custom plugins folder.
+
+```console
+git clone git@github.com:wadewegner/salesforce-cli-zsh-completion.git ~/.oh-my-zsh/custom/plugins/salesforce-cli-zsh-completion
+```
+
+Enable it by editing `~/.zshrc`. Add `salesforce-cli-zsh-completion` to the list of extra plugins, like this:
+
+```sh
+# ~/.zshrc
+plugins=(salesforce-cli-zsh-completion)
+```
+
+Reload your shell and enjoy.

--- a/salesforce-cli-zsh-completion.plugin.zsh
+++ b/salesforce-cli-zsh-completion.plugin.zsh
@@ -1,0 +1,8 @@
+# This is a placeholder file that allows [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+# to autoload this code as a plugin.
+#
+# To install, move this directory to:
+#   ~/.oh-my-zsh/custom/plugins/salesforce-cli-zsh-completion
+#
+# And edit ~/.zshrc:
+#   plugins=(salesforce-cli-zsh-completion)


### PR DESCRIPTION
This PR allows to auto-completion to be installed as a plugin of oh-my-zsh. It's done by satisfying the `is_plugin()` check in https://github.com/robbyrussell/oh-my-zsh/blob/master/oh-my-zsh.sh#L38.