### PR TITLE
Explicitly enabled interpretation of backslash escapes

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -101,4 +101,4 @@ completion+="\n_arguments \\\\"
 completion+="\n  \$_command_args \\\\"
 completion+="\n  && return 0"
 
-echo $completion > _sfdx
+[[ "$(uname)" == "Linux" ]] && echo -e $completion > _sfdx || echo $completion > _sfdx


### PR DESCRIPTION
Under Linux the interpretation of escapes is disabled by default, hence `-e` flag is needed otherwise `\n` are treated as a string literal.